### PR TITLE
Optional max groups size & number of groups

### DIFF
--- a/randomgroups/algorithm.py
+++ b/randomgroups/algorithm.py
@@ -14,7 +14,7 @@ def find_best_matching(
         matchings_history (pd.DataFrame): Square df containing group information. Index
             and column is given by the 'id' column in src/data/names.csv.
         matching_params (dict): Parameters that govern the behavior of the matching
-            criterion. Default None. For detais see ``_add_defaults_params``.
+            criterion. Default None. For details see ``_add_defaults_params``.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
 
@@ -69,7 +69,7 @@ def _compute_assortativity_score(matching, matching_params):
 
     Args:
         matching (list): Matching.
-        matching_params (dict): Dictionary containig matching parameters.
+        matching_params (dict): Dictionary containing matching parameters.
 
     Returns:
         score (float): The corresponding score.
@@ -148,8 +148,7 @@ def _create_candidate_matching(participants, min_size, seed):
             'joins'(0/1), 'status'(student/faculty) and 'wants_mixing'(0/1)'. But only
             rows with joins equal to 1 are selected.
         min_size (int): Minimum group size.
-        n_candidates (int): Number of candidate groups to simulate.
-        initial_seed (int): Initial seed to pass to the seed generator.
+        seed (int): Initial seed to pass to the seed generator.
 
     Returns:
         candidate (list): Matching candidate.

--- a/randomgroups/read_and_write.py
+++ b/randomgroups/read_and_write.py
@@ -9,7 +9,7 @@ def read_names(names_path, file_type="csv"):
     """Read names file.
 
     Reads names file if stored locally and downloads it if url is given instead. This
-    exepects that the file is directly downloadable from the url. For example, if you
+    expects that the file is directly downloadable from the url. For example, if you
     want to download a google sheet you have to publish the document in the file
     settings of the google to get a "direct-download" link.
 
@@ -45,7 +45,7 @@ def read_or_create_matchings_history(matchings_history_path, names):
     Returns:
         matchings_history (pd.DataFrame): df with columns and rows equal to the 'id'
             column in names df (see func ``read_names``). Cell entries represent number
-            meetings of the row individual with the column indidivual.
+            meetings of the row individual with the column individual.
 
     """
     if matchings_history_path is None:
@@ -141,7 +141,7 @@ def write_file(to_write, path):
 
 
 def format_matching_as_str(matching):
-    """Format matching in human readable string.
+    """Format matching in human-readable string.
 
     Args:
         matching (list): Matching in list form.


### PR DESCRIPTION
two new functionalities added:
1. one can now specify `n_groups` instead of `min_size` to get matchings according to the defined number of groups. This option checks if  `min_size` can still be fulfilled.
2. the optional `max_size` limits the members per group by excluding participants (those with most matchings in history). This is especially useful to enforce pair-wise matchings. This option checks if it can be combined with `n_groups` and `min_size`.

All added functionalities have been tested on the example list of participants.