### PR TITLE
Add assortative matching with multiple statuses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.8
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.13.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Introduction
 
 This package exports a single function called `create_matching` which can be used to
-create matchings for reccuring meetings from a varying but overlapping set of members.
+create matchings for reoccurring meetings from a varying but overlapping set of members.
 In particular, the internal algorithm makes sure that matchings at different meetings
 are mixed.
 
@@ -59,7 +59,7 @@ used in subsequent function calls. Example files are given here:
 [matchings_history.csv](https://github.com/timmens/random-grouping/blob/main/tests/data/matchings_history.csv).
 
 *Remark:* If the files `names.csv` is a Google sheet which is updated on a regular basis
-it can be sensible not to donwload the file but to provide a link to the sheet directly.
+it can be sensible not to download the file but to provide a link to the sheet directly.
 In the case with Google sheets this is easily done by opening the Google sheet and then
 publishing the document in the file options. This creates a link to a downloadable csv
 file which updates when the Google sheet is updated. This URL can then be passed to
@@ -73,12 +73,13 @@ will then influence new group formations.
 
 **Assortative Matching:**
 
-The 'status' column in the names csv-file allows one to distuingish between 'student'
-and 'faculty'. One can then use the 'wants_mixing' column to specify whether an
-individual wants to be mixed with people from another group. This is not absolute. A
-float parameter ("faculty_multiplier") can be specified in a dictionary an passed to the
-main function via the argument "matching_params". If this parameter is very high it will
-be less likely that faculty that does not want to mix is mixed.
+The 'status' column in the names csv-file allows one to distinguish between different
+stati like 'student' or 'faculty'. One can then use the 'wants_mixing' column to specify
+whether an individual wants to be mixed with people from another group. This is not
+absolute. A float parameter ("mixing_multiplier") can be specified. If this parameter is
+very high it will be less likely that people with a different status and which do not
+want to mix are mixed. In fact, a negative value will make it more likely that people
+with a different status are mixed.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Introduction
 
 This package exports a single function called `create_matching` which can be used to
-create matchings for reoccurring meetings from a varying but overlapping set of members.
+create matchings for recurring meetings from a varying but overlapping set of members.
 In particular, the internal algorithm makes sure that matchings at different meetings
 are mixed.
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ will then influence new group formations.
 **Assortative Matching:**
 
 The 'status' column in the names csv-file allows one to distinguish between different
-stati like 'student' or 'faculty'. One can then use the 'wants_mixing' column to specify
-whether an individual wants to be mixed with people from another group. This is not
-absolute. A float parameter ("mixing_multiplier") can be specified. If this parameter is
-very high it will be less likely that people with a different status and which do not
-want to mix are mixed. In fact, a negative value will make it more likely that people
-with a different status are mixed.
+statuses like 'student' or 'faculty'. One can then use the 'wants_mixing' column to
+specify whether an individual wants to be mixed with people from another group. This is
+not absolute. A float parameter ("mixing_multiplier") can be specified. If this
+parameter is very high it will be less likely that people with a different status and
+which do not want to mix are mixed. In fact, a negative value will make it more likely
+that people with a different status are mixed.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ specify whether an individual wants to be mixed with people from another group. 
 not absolute. A float parameter ("mixing_multiplier") can be specified. If this
 parameter is very high it will be less likely that people with a different status and
 which do not want to mix are mixed. In fact, a negative value will make it more likely
-that people with a different status are mixed.
+that people with a different status are mixed. Multiple status columns can be used,
+e.g., "status", "status2", etc. and a dict of mixing multipliers can be passed to get
+different mixing multipliers for different status columns.
 
 # Contributing
 

--- a/src/randomgroups/algorithm.py
+++ b/src/randomgroups/algorithm.py
@@ -89,13 +89,13 @@ def _compute_assortativity_score(
     """
     score = 0.0
     for group in matching:
-        unique_stati = group.status.unique()
-        n_unique_stati = len(unique_stati)
-        if n_unique_stati > 1:
+        unique_status = group.status.unique()
+        n_unique_status = len(unique_status)
+        if n_unique_status > 1:
             if "wants_mixing" not in group.columns:
                 group["wants_mixing"] = 0
             wants_assortative = 1 - group.wants_mixing
-            wants_assortative *= mixing_multiplier * n_unique_stati
+            wants_assortative *= mixing_multiplier * n_unique_status
             score += wants_assortative.mean()
 
     return score

--- a/src/randomgroups/algorithm.py
+++ b/src/randomgroups/algorithm.py
@@ -20,8 +20,8 @@ def find_optimal_matching(
             and column is given by the 'id' column in src/data/names.csv.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
-        mixing_multiplier (float, List[float]): Multiplier determining how many members of
-            different status want to stay in the same group. Positive values favor
+        mixing_multiplier (float, List[float]): Multiplier determining how many members
+            of different status want to stay in the same group. Positive values favor
             assortative matchings, negative values favor mixed matchings.
             Can only be used if assortative_matching is True.
         assortative_matching (bool): Whether to use assortative matching.
@@ -79,8 +79,8 @@ def _compute_assortativity_score(
 
     Args:
         matching (list): Matching.
-        mixing_multiplier (float, List[float]): Multiplier determining how many members of
-            different status want to stay in the same group. Positive values favor
+        mixing_multiplier (float, List[float]): Multiplier determining how many members
+            of different status want to stay in the same group. Positive values favor
             assortative matchings, negative values favor mixed matchings.
 
     Returns:
@@ -92,9 +92,6 @@ def _compute_assortativity_score(
 
     score = 0.0
     for group in matching:
-        if "wants_mixing" not in group.columns:
-            # if not, assume that no-one wants mixing
-            group["wants_mixing"] = 0
         for s_idx, status in enumerate(statuses_columns):
             unique_status = group[status].dropna().unique()
             n_unique_status = len(unique_status)

--- a/src/randomgroups/algorithm.py
+++ b/src/randomgroups/algorithm.py
@@ -9,7 +9,7 @@ def find_optimal_matching(
     candidates: List[List[pd.DataFrame]],
     matchings_history: pd.DataFrame,
     penalty_func: callable,
-    faculty_multiplier: float,
+    mixing_multiplier: float,
     assortative_matching: bool,
 ) -> List[pd.DataFrame]:
     """Find best matching from list of candidates.
@@ -20,8 +20,10 @@ def find_optimal_matching(
             and column is given by the 'id' column in src/data/names.csv.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
-        faculty_multiplier (float): Multiplier determining how much faculty members
-            want to stay in the same group.
+        mixing_multiplier (float): Multiplier determining how many members of different
+            status want to stay in the same group. Positive values favor assortative
+            matchings, negative values favor mixed matchings.
+            Can only be used if assortative_matching is True.
         assortative_matching (bool): Whether to use assortative matching.
 
     Returns:
@@ -33,7 +35,7 @@ def find_optimal_matching(
         updated_history = update_matchings_history(matchings_history, matching)
         score = _compute_history_score(updated_history, penalty_func)
         if assortative_matching:
-            score += _compute_assortativity_score(matching, faculty_multiplier)
+            score += _compute_assortativity_score(matching, mixing_multiplier)
         criterion_values.append(score)
 
     optimal_matching = candidates[np.argmin(criterion_values)]
@@ -68,7 +70,7 @@ def _compute_history_score(
 
 
 def _compute_assortativity_score(
-    matching: List[pd.DataFrame], faculty_multiplier: float
+    matching: List[pd.DataFrame], mixing_multiplier: float
 ) -> float:
     """Compute assortativity score.
 
@@ -77,8 +79,9 @@ def _compute_assortativity_score(
 
     Args:
         matching (list): Matching.
-        faculty_multiplier (float): Multiplier determining how much faculty members
-            want to stay in the same group.
+         mixing_multiplier (float): Multiplier determining how many members of different
+            status want to stay in the same group. Positive values favor assortative
+            matchings, negative values favor mixed matchings.
 
     Returns:
         float: The corresponding score.
@@ -86,9 +89,13 @@ def _compute_assortativity_score(
     """
     score = 0.0
     for group in matching:
-        if len(group.status.unique()) > 1:
+        unique_stati = group.status.unique()
+        n_unique_stati = len(unique_stati)
+        if n_unique_stati > 1:
+            if "wants_mixing" not in group.columns:
+                group["wants_mixing"] = 0
             wants_assortative = 1 - group.wants_mixing
-            wants_assortative.loc[group.status == "faculty"] *= faculty_multiplier
+            wants_assortative *= mixing_multiplier * n_unique_stati
             score += wants_assortative.mean()
 
     return score

--- a/src/randomgroups/algorithm.py
+++ b/src/randomgroups/algorithm.py
@@ -1,5 +1,5 @@
 from itertools import combinations
-from typing import List, Union
+from typing import List, Union, Dict
 
 import numpy as np
 import pandas as pd
@@ -9,7 +9,7 @@ def find_optimal_matching(
     candidates: List[List[pd.DataFrame]],
     matchings_history: pd.DataFrame,
     penalty_func: callable,
-    mixing_multiplier: List[float],
+    mixing_multiplier: Dict[str, float],
     assortative_matching: bool,
 ) -> List[pd.DataFrame]:
     """Find best matching from list of candidates.
@@ -20,7 +20,7 @@ def find_optimal_matching(
             and column is given by the 'id' column in src/data/names.csv.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
-        mixing_multiplier (float, List[float]): Multiplier determining how many members
+        mixing_multiplier (Dict[str, float]): Multiplier determining how many members
             of different status want to stay in the same group. Positive values favor
             assortative matchings, negative values favor mixed matchings.
             Can only be used if assortative_matching is True.
@@ -70,7 +70,7 @@ def _compute_history_score(
 
 
 def _compute_assortativity_score(
-    matching: List[pd.DataFrame], mixing_multiplier: List[float]
+    matching: List[pd.DataFrame], mixing_multiplier: Dict[str, float]
 ) -> float:
     """Compute assortativity score.
 
@@ -79,7 +79,7 @@ def _compute_assortativity_score(
 
     Args:
         matching (list): Matching.
-        mixing_multiplier (float, List[float]): Multiplier determining how many members
+        mixing_multiplier (Dict[str, float]): Multiplier determining how many members
             of different status want to stay in the same group. Positive values favor
             assortative matchings, negative values favor mixed matchings.
 
@@ -92,12 +92,12 @@ def _compute_assortativity_score(
 
     score = 0.0
     for group in matching:
-        for s_idx, status in enumerate(statuses_columns):
+        for status in statuses_columns:
             unique_status = group[status].dropna().unique()
             n_unique_status = len(unique_status)
             if n_unique_status > 1:
                 wants_assortative = 1 - group.wants_mixing
-                wants_assortative *= mixing_multiplier[s_idx] * n_unique_status
+                wants_assortative *= mixing_multiplier[status] * n_unique_status
                 score += wants_assortative.mean()
     return score
 

--- a/src/randomgroups/algorithm.py
+++ b/src/randomgroups/algorithm.py
@@ -20,7 +20,7 @@ def find_optimal_matching(
             and column is given by the 'id' column in src/data/names.csv.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
-        mixing_multiplier (float, List): Multiplier determining how many members of
+        mixing_multiplier (float, List[float]): Multiplier determining how many members of
             different status want to stay in the same group. Positive values favor
             assortative matchings, negative values favor mixed matchings.
             Can only be used if assortative_matching is True.

--- a/src/randomgroups/algorithm.py
+++ b/src/randomgroups/algorithm.py
@@ -79,7 +79,7 @@ def _compute_assortativity_score(
 
     Args:
         matching (list): Matching.
-         mixing_multiplier (float, List): Multiplier determining how many members of
+        mixing_multiplier (float, List[float]): Multiplier determining how many members of
             different status want to stay in the same group. Positive values favor
             assortative matchings, negative values favor mixed matchings.
 

--- a/src/randomgroups/create_matching.py
+++ b/src/randomgroups/create_matching.py
@@ -122,6 +122,12 @@ def create_matching(
                 "equal to the number of statuses."
             )
 
+        # check if wants_mixing column is specified
+        # if not, assume that no-one wants mixing
+        # (otherwise one should set assortative_matching=False)
+        if "wants_mixing" not in all_participants.columns:
+            all_participants["wants_mixing"] = 0
+
     matchings_history = read_or_create_matchings_history(
         names=names,
         path=matchings_history_path,

--- a/src/randomgroups/create_matching.py
+++ b/src/randomgroups/create_matching.py
@@ -23,7 +23,7 @@ def create_matching(
     n_groups: Optional[int] = None,
     max_size: Optional[int] = None,
     penalty_func: callable = np.exp,
-    faculty_multiplier: float = 3.0,
+    mixing_multiplier: float = 3.0,
     assortative_matching: bool = False,
     n_draws: int = 1_000,
     seed: int = 12345,
@@ -44,8 +44,10 @@ def create_matching(
             If None, no maximum size is enforced.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
-        faculty_multiplier (float): Multiplier determining how much faculty members
-            want to stay in the same group.
+         mixing_multiplier (float): Multiplier determining how many members of different
+            status want to stay in the same group. Positive values favor assortative
+            matchings, negative values favor mixed matchings.
+            Can only be used if assortative_matching is True.
         assortative_matching (bool): Whether to use assortative matching.
         n_draws (int): Number of candidate groups to try during loss minimization.
         seed (int): Seed from which to start the seed generator.
@@ -175,7 +177,7 @@ def create_matching(
         candidates=list_of_matchings,
         matchings_history=matchings_history,
         penalty_func=penalty_func,
-        faculty_multiplier=faculty_multiplier,
+        mixing_multiplier=mixing_multiplier,
         assortative_matching=assortative_matching,
     )
 

--- a/src/randomgroups/create_matching.py
+++ b/src/randomgroups/create_matching.py
@@ -16,9 +16,9 @@ from randomgroups.io import write_matchings_history
 
 
 def create_matching(
-    names_path: Union[str, Path] = None,
-    matchings_history_path: Union[str, Path] = None,
-    output_path: Union[str, Path] = None,
+    names_path: Union[str, Path],
+    matchings_history_path: Optional[Union[str, Path]] = None,
+    output_path: Optional[Union[str, Path]] = None,
     min_size: int = 2,
     n_groups: Optional[int] = None,
     max_size: Optional[int] = None,
@@ -70,7 +70,9 @@ def create_matching(
         )
 
     names_path = Path(names_path)
-    matchings_history_path = Path(matchings_history_path)
+    matchings_history_path = (
+        None if matchings_history_path is None else Path(matchings_history_path)
+    )
     output_path = None if output_path is None else Path(output_path)
 
     test_penalties = penalty_func(np.array([1, 2]))
@@ -145,7 +147,7 @@ def create_matching(
         n_to_exclude = 0
 
     # ==================================================================================
-    # Exclude participants if neccessary
+    # Exclude participants if necessary
     # ==================================================================================
 
     participants = _exclude_participants_with_most_matchings(

--- a/src/randomgroups/create_matching.py
+++ b/src/randomgroups/create_matching.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from typing import Union, Optional, List
+from typing import Union, Optional, Dict
 
 from randomgroups.algorithm import draw_candidate_matchings
 from randomgroups.algorithm import find_optimal_matching
@@ -23,7 +23,7 @@ def create_matching(
     n_groups: Optional[int] = None,
     max_size: Optional[int] = None,
     penalty_func: callable = np.exp,
-    mixing_multiplier: Union[float, List[float]] = 3.0,
+    mixing_multiplier: Union[float, Dict[str, float]] = 3.0,
     assortative_matching: bool = False,
     n_draws: int = 1_000,
     seed: int = 12345,
@@ -44,10 +44,10 @@ def create_matching(
             If None, no maximum size is enforced.
         penalty_func (callable): Penalty function, defaults to np.exp. Is applied to
             punish large values in matchings_history.
-        mixing_multiplier (float, List): Multiplier determining how many members of
-            different status want to stay in the same group. Positive values favor
-            assortative matchings, negative values favor mixed matchings. Can be a
-            list if there are multiple statuses and can only be used if
+        mixing_multiplier (float, Dict[str, float]): Multiplier determining how many
+            members of different status want to stay in the same group. Positive values
+            favor assortative matchings, negative values favor mixed matchings. Can be
+            a dict with statuses as keys and can only be used if
             assortative_matching is True.
         assortative_matching (bool): Whether to use assortative matching.
         n_draws (int): Number of candidate groups to try during loss minimization.
@@ -115,11 +115,13 @@ def create_matching(
 
         # check if mixing_multiplier is valid
         if isinstance(mixing_multiplier, (float, int)):
-            mixing_multiplier = [mixing_multiplier] * len(statuses_columns)
-        elif len(mixing_multiplier) != len(statuses_columns):
+            mixing_multiplier = {
+                status: mixing_multiplier for status in statuses_columns
+            }
+        elif set(mixing_multiplier.keys()) != set(statuses_columns):
             raise ValueError(
-                "'mixing_multiplier' must be float or list of length "
-                "equal to the number of statuses."
+                "'mixing_multiplier' must be a float or a dict with keys "
+                "equal to the statuses."
             )
 
         # check if wants_mixing column is specified

--- a/tests/data/names_assortative.csv
+++ b/tests/data/names_assortative.csv
@@ -1,0 +1,7 @@
+id,name,joins,status
+0,Antonia,1,faculty1
+1,Daniel,1,faculty1
+2,Fabio,1,faculty2
+3,Lukas,0,faculty2
+4,Luis,1
+5,Paul,1,faculty3

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -7,6 +7,7 @@ from randomgroups.algorithm import (
     update_matchings_history,
     update_min_size_using_n_groups,
     get_number_of_excluded_participants,
+    _compute_assortativity_score,
 )
 import pandas as pd
 from collections import namedtuple
@@ -126,3 +127,59 @@ def test_get_number_of_excluded_participants_equal_max_min():
         n_participants=5,
     )
     assert got == (1, False)
+
+
+def test_compute_assortativity_score():
+    matching = [
+        pd.DataFrame(
+            {"name": ["Alice", "Bob"], "status": ["faculty1", "faculty1"]}, index=[0, 1]
+        ),
+    ]
+    got = _compute_assortativity_score(matching, mixing_multiplier=3.0)
+    assert got == 0.0
+
+    matching = [
+        pd.DataFrame(
+            {"name": ["Alice", "Bob"], "status": ["faculty1", "faculty2"]}, index=[0, 1]
+        ),
+    ]
+    got = _compute_assortativity_score(matching, mixing_multiplier=3.0)
+    assert got == 6.0
+
+    matching = [
+        pd.DataFrame(
+            {
+                "name": ["Alice", "Bob", "Jack"],
+                "status": ["faculty1", "faculty2", "faculty2"],
+            },
+            index=[0, 1, 3],
+        ),
+    ]
+    got = _compute_assortativity_score(matching, mixing_multiplier=3.0)
+    assert got == 6.0
+
+    matching = [
+        pd.DataFrame(
+            {
+                "name": ["Alice", "Bob", "Jack"],
+                "status": ["faculty1", "faculty2", "faculty2"],
+                "wants_mixing": [1, 1, 1],
+            },
+            index=[0, 1, 3],
+        ),
+    ]
+    got = _compute_assortativity_score(matching, mixing_multiplier=3.0)
+    assert got == 0.0
+
+    matching = [
+        pd.DataFrame(
+            {
+                "name": ["Alice", "Bob", "Jack"],
+                "status": ["faculty1", "faculty2", "faculty2"],
+                "wants_mixing": [0, 0, 1],
+            },
+            index=[0, 1, 3],
+        ),
+    ]
+    got = _compute_assortativity_score(matching, mixing_multiplier=3.0)
+    assert got == 4.0

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -140,7 +140,7 @@ def test_compute_assortativity_score():
             index=[0, 1],
         ),
     ]
-    got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
+    got = _compute_assortativity_score(matching, mixing_multiplier={"status": 3.0})
     assert got == 0.0
 
     matching = [
@@ -153,7 +153,7 @@ def test_compute_assortativity_score():
             index=[0, 1],
         ),
     ]
-    got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
+    got = _compute_assortativity_score(matching, mixing_multiplier={"status": 3.0})
     assert got == 6.0
 
     matching = [
@@ -166,7 +166,7 @@ def test_compute_assortativity_score():
             index=[0, 1, 3],
         ),
     ]
-    got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
+    got = _compute_assortativity_score(matching, mixing_multiplier={"status": 3.0})
     assert got == 6.0
 
     matching = [
@@ -179,7 +179,7 @@ def test_compute_assortativity_score():
             index=[0, 1, 3],
         ),
     ]
-    got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
+    got = _compute_assortativity_score(matching, mixing_multiplier={"status": 3.0})
     assert got == 0.0
 
     matching = [
@@ -192,7 +192,7 @@ def test_compute_assortativity_score():
             index=[0, 1, 3],
         ),
     ]
-    got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
+    got = _compute_assortativity_score(matching, mixing_multiplier={"status": 3.0})
     assert got == 4.0
 
 
@@ -208,5 +208,7 @@ def test_compute_assortativity_score_statuses():
             index=[0, 1, 3],
         ),
     ]
-    got = _compute_assortativity_score(matching, mixing_multiplier=[3.0, -1.0])
+    got = _compute_assortativity_score(
+        matching, mixing_multiplier={"status": 3.0, "status2": -1.0}
+    )
     assert got == 4.0

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -132,7 +132,12 @@ def test_get_number_of_excluded_participants_equal_max_min():
 def test_compute_assortativity_score():
     matching = [
         pd.DataFrame(
-            {"name": ["Alice", "Bob"], "status": ["faculty1", "faculty1"]}, index=[0, 1]
+            {
+                "name": ["Alice", "Bob"],
+                "status": ["faculty1", "faculty1"],
+                "wants_mixing": [0, 0],
+            },
+            index=[0, 1],
         ),
     ]
     got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
@@ -140,7 +145,12 @@ def test_compute_assortativity_score():
 
     matching = [
         pd.DataFrame(
-            {"name": ["Alice", "Bob"], "status": ["faculty1", "faculty2"]}, index=[0, 1]
+            {
+                "name": ["Alice", "Bob"],
+                "status": ["faculty1", "faculty2"],
+                "wants_mixing": [0, 0],
+            },
+            index=[0, 1],
         ),
     ]
     got = _compute_assortativity_score(matching, mixing_multiplier=[3.0])
@@ -151,6 +161,7 @@ def test_compute_assortativity_score():
             {
                 "name": ["Alice", "Bob", "Jack"],
                 "status": ["faculty1", "faculty2", "faculty2"],
+                "wants_mixing": [0, 0, 0],
             },
             index=[0, 1, 3],
         ),
@@ -192,6 +203,7 @@ def test_compute_assortativity_score_statuses():
                 "name": ["Alice", "Bob", "Jack"],
                 "status": ["faculty1", "faculty2", "faculty2"],
                 "status2": ["roomX", "roomX", "roomY"],
+                "wants_mixing": [0, 0, 0],
             },
             index=[0, 1, 3],
         ),

--- a/tests/test_create_matching.py
+++ b/tests/test_create_matching.py
@@ -134,6 +134,42 @@ def test_create_matching_max_size_no_exclusion():
         assert set(group.name) in expected_groups
 
 
+def test_assortative_matching():
+    result = create_matching(
+        names_path=TEST_DATA.joinpath("names_assortative.csv"),
+        min_size=2,
+        seed=1,
+        mixing_multiplier=1,
+        assortative_matching=True,
+        return_results=True,
+    )
+
+    # groups should be sorted by faculty
+    expected_groups = [
+        {"Daniel", "Antonia"},
+        {"Paul", "Luis", "Fabio"},
+    ]
+    for group in result["matching"]:
+        assert set(group.name) in expected_groups
+
+    result = create_matching(
+        names_path=TEST_DATA.joinpath("names_assortative.csv"),
+        min_size=2,
+        seed=1,
+        mixing_multiplier=-1,
+        assortative_matching=True,
+        return_results=True,
+    )
+
+    # groups should be as mixed as possible
+    expected_groups = [
+        {"Daniel", "Luis", "Paul"},
+        {"Antonia", "Fabio"},
+    ]
+    for group in result["matching"]:
+        assert set(group.name) in expected_groups
+
+
 # ======================================================================================
 # Helper functions
 # ======================================================================================


### PR DESCRIPTION
- Add functionality for having people with more than two statuses
- Tests added for assortative matching

Use-Case:
Using a negative `mixing_multiplier` results in groups favouring people which differ more in their status. 
I believe this will be helpful for users who want to create more diverse groups.